### PR TITLE
feat: 🎸 activation - expired

### DIFF
--- a/src/generics/response-types.ts
+++ b/src/generics/response-types.ts
@@ -7,6 +7,7 @@ export enum ResponseErrorTypes {
     CognitoUserNotFound = 'UserNotFoundException',
     CognitoUserAlreadyExists = 'UserAlreadyExistsException',
     Unauthorized = 'Unauthorized',
+    InvalidToken = 'InvalidToken',
 }
 
 export enum ResponseSuccessTypes {

--- a/src/libs/response-helper.ts
+++ b/src/libs/response-helper.ts
@@ -15,7 +15,10 @@ export function toErrorResponse(errors: Record<string, unknown>, status_code = 4
     let statusCode = status_code
 
     try {
-        const { name, message } = errors
+        const { name, message, type } = errors
+        if (type) {
+            response.type = type as ResponseErrorTypes
+        }
         const { details } = errors as unknown as { details: JoiErrorDetails[] }
         if (details) {
             response.errors = details.map((joi_error: JoiErrorDetails) => {

--- a/src/services/auth/models/index.ts
+++ b/src/services/auth/models/index.ts
@@ -1,6 +1,25 @@
-import { AdminCreateUserCommand, AdminCreateUserCommandOutput, AdminDisableUserCommand, AdminGetUserCommand, AdminGetUserCommandOutput, AdminSetUserPasswordCommand, CognitoIdentityProviderClient, MessageActionType } from '@aws-sdk/client-cognito-identity-provider'
+import { AdminCreateUserCommand, AdminCreateUserCommandOutput, AdminDisableUserCommand, AdminEnableUserCommand, AdminEnableUserCommandOutput, AdminGetUserCommand, AdminGetUserCommandOutput, AdminSetUserPasswordCommand, CognitoIdentityProviderClient, MessageActionType } from '@aws-sdk/client-cognito-identity-provider'
 import { cognito, config } from 'generics/config'
 import { ResponseErrorTypes } from 'generics/response-types'
+
+export async function activate(Username: string): Promise<AdminEnableUserCommandOutput | { error: string, message: string }> {
+    const client = new CognitoIdentityProviderClient(cognito)
+
+    let record
+    try {
+        record = await client.send(
+            new AdminEnableUserCommand({
+                UserPoolId: config.ARMADA_COGNITO_POOL_ID,
+                Username,
+            })
+        )
+    } catch (error) {
+        const { name, message } = error as Record<string, string>
+        record = { error: name, message }
+    }
+
+    return record
+}
 
 export async function signUp(
     email: string,

--- a/stacks/ApiAuthStack.ts
+++ b/stacks/ApiAuthStack.ts
@@ -17,6 +17,7 @@ export function ApiAuthStack(this: any, { stack }: StackContext) {
         },
         routes: {
             'POST /signup': 'services/auth/controllers/main.signUp',
+            'GET /activate': 'services/auth/controllers/main.activate',
         },
     })
 


### PR DESCRIPTION
- Create an activate account endpoint

Test for cases:
- If activation link has expired. (15 minutes), redirect to a web page to request for email of the signee.
- Activation link is valid, activate the account and redirect user to login page.